### PR TITLE
Starting a time entry is a POST not a PUT

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.7.0
+requests[security]==2.19.1
 wheel==0.24.0

--- a/togglwrapper/api.py
+++ b/togglwrapper/api.py
@@ -153,7 +153,8 @@ class TimeEntries(TogglObject, GetMixin, CreateMixin, UpdateMixin,
 
     def start(self, data):
         """ Starts a new time entry. """
-        return super(TimeEntries, self).update(child_uri='/start', data=data)
+        uri = self._compile_uri(child_uri='/start')
+        return self.toggl.post(uri, data=data)
 
     def stop(self, time_entry_id):
         """ Stops the time entry with the given ID. """


### PR DESCRIPTION
As per the [Toggl v8 api docs](https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md), starting a time entry is a POST to `/time_entries/start`, not a PUT. A PUT returns an API error.