### PR TITLE
(fix) Creating time entries

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -489,7 +489,7 @@ class TestTimeEntries(TestTogglBase):
     @responses.activate
     def test_start(self):
         """ Should start a TimeEntry. """
-        self.responses_add('PUT', 'time_entry_start', child_uri='/start')
+        self.responses_add('POST', 'time_entry_start', child_uri='/start')
         start_data = {"time_entry": {
             "description": "Meeting with possible clients",
             "tags": ["billed"],

--- a/togglwrapper/api.py
+++ b/togglwrapper/api.py
@@ -153,7 +153,7 @@ class TimeEntries(TogglObject, GetMixin, CreateMixin, UpdateMixin,
 
     def start(self, data):
         """ Starts a new time entry. """
-        return super(TimeEntries, self).update(child_uri='/start', data=data)
+        return super(TimeEntries, self).create(child_uri='/start', data=data)
 
     def stop(self, time_entry_id):
         """ Stops the time entry with the given ID. """

--- a/togglwrapper/mixins.py
+++ b/togglwrapper/mixins.py
@@ -38,14 +38,17 @@ class GetMixin(object):
 
 class CreateMixin(object):
     """ Mixin to add create methods to a class. """
-    def create(self, data):
+    def create(self, data, child_uri=None):
         """
         Creates a new instance of the object type.
 
         Args:
             data (dict): The dict of information needed to create a new object.
+            child_uri (str, optional): The URI of the child Object or subpath.
+                Defaults to None.
         """
-        return self.toggl.post(self.uri, data)
+        uri = self._compile_uri(child_uri=child_uri)
+        return self.toggl.post(uri, data)
 
 
 class UpdateMixin(object):


### PR DESCRIPTION
Fix for issue #4 

- Refactored `CreateMixin` to accept `child_uri` param, similar to `UpdateMixin`
- Switch to using create/POST instead of update/PUT for creating new time entries
- Updated test to accurately reflect time entry creation behaviour 