### PR TITLE
don't pin `requests` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,12 @@ setup(
     package_data={'': ['LICENSE', 'NOTICE']},
 
     # List run-time dependencies here.
-    install_requires=requirements,
+    install_requires=[
+        "requests",
+    ],
 
-    # Development dependencies. Install using :
+    # Development dependencies. Install using `pip install -e .[dev]`
     extras_require={
-        'dev': test_requirements,
+        'dev': requirements + test_requirements,
     },
 )


### PR DESCRIPTION
Thanks again for releasing togglwrapper.

While pinning all dependencies in CI is a good idea to avoid contributors having to deal with spurious version-upgrade problems as they're trying to contribute unrelated fixes, it's unfortunately a problem for applications, which need to upgrade their dependencies on a more regular cadence than togglwrapper maintenance has bandwidth for.  There's always the possibility of a new version of `requests` breaking things, but that's really the responsibility of the `requests` maintainers to keep things working.

This distinction between `setup.py` and `requirements.txt` is somewhat subtle, but Donald Stufft tried to explain it in some depth here: https://caremad.io/posts/2013/07/setup-vs-requirement/

Separately from this PR, it might be good to ~~get a (free!) account on [Requires.io](http://requires.io/),~~ turn on [Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) which can automatically send you a PR when any of your Python dependencies upgrade, which will take care of both `requirements.txt` and `test_requirements.txt` for you.